### PR TITLE
Add dev setup for basic cookiecutter

### DIFF
--- a/{{cookiecutter.package_name}}/{{cookiecutter.import_name}}/app/controller.py
+++ b/{{cookiecutter.package_name}}/{{cookiecutter.import_name}}/app/controller.py
@@ -2,7 +2,7 @@ r"""
 Bind methods to the trame controller
 """
 
-from trame import controller as ctrl, state
+from trame import controller as ctrl
 from . import engine
 
 
@@ -14,5 +14,17 @@ def bind_methods():
     ctrl.widget_change = engine.widget_change
 
 
-def bind_changes():
-    state.change("my_title")(engine.title_change)
+def on_start():
+    """Method called for initialization when the application starts"""
+    bind_methods()
+
+
+def on_reload(reload_modules):
+    """Method called when the module is reloaded
+
+    reload_modules is a function that takes modules to reload
+
+    We only need to reload the controller if the engine is reloaded.
+    """
+    # reload_modules(engine)
+    bind_methods()

--- a/{{cookiecutter.package_name}}/{{cookiecutter.import_name}}/app/engine.py
+++ b/{{cookiecutter.package_name}}/{{cookiecutter.import_name}}/app/engine.py
@@ -33,6 +33,6 @@ def widget_change():
 # Listeners
 # ---------------------------------------------------------
 
-
+@state.change("my_title")
 def title_change(my_title, **kwargs):
     print(f" => title changed to {my_title}")

--- a/{{cookiecutter.package_name}}/{{cookiecutter.import_name}}/app/main.py
+++ b/{{cookiecutter.package_name}}/{{cookiecutter.import_name}}/app/main.py
@@ -1,18 +1,19 @@
-from .controller import bind_changes, bind_methods
-from .ui import layout
+from trame import setup_dev
+
+from . import controller, ui
 
 
 def start_server():
-    layout.start()
+    setup_dev(ui, controller)
+    ui.layout.start()
 
 
 def start_desktop():
-    layout.start_desktop_window()
+    ui.layout.start_desktop_window()
 
 
 def main():
-    bind_changes()
-    bind_methods()
+    controller.on_start()
     start_server()
 
 


### PR DESCRIPTION
Now, if the user runs their trame app with the `--dev` argument, the reload
button will appear at the bottom of the web browser. Pressing it will cause
the UI file to be reloaded and updated, which allows for the UI to be
developed and updated without closing the program.

This additionally reloads the controller file, which, after reload, will also
call the `on_reload()` function, which is given a function that can be used to
reload other modules.

Depends on: kitware/trame#34