### PR TITLE
Fix license classifiers

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -3,7 +3,7 @@
     "project_type": ["App", "App with Components", "Components"],
     "author": "Trame Developer",
     "short_description": "An example Trame application",
-    "license": ["BSD license", "MIT license", "ISC license", "Apache Software License 2.0", "GNU General Public License v3", "Other"],
+    "license": ["BSD License", "MIT License", "ISC License (ISCL)", "Apache Software License", "GNU General Public License v3 (GPLv3)", "Other"],
     "package_name": "{{ cookiecutter.project_name.lower().replace(' ', '-') }}",
     "import_name": "{{ cookiecutter.package_name.lower().replace('-', '_') }}"
 }

--- a/{{cookiecutter.package_name}}/LICENSE
+++ b/{{cookiecutter.package_name}}/LICENSE
@@ -1,4 +1,4 @@
-{% if cookiecutter.license == 'BSD license' -%}
+{% if cookiecutter.license == 'BSD License' -%}
 BSD 3-Clause
 
 Copyright (c) {% now 'local', '%Y' %}, {{ cookiecutter.author }}
@@ -28,7 +28,7 @@ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
 OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
 OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
 OF THE POSSIBILITY OF SUCH DAMAGE.
-{% elif cookiecutter.license == 'MIT license' -%}
+{% elif cookiecutter.license == 'MIT License' -%}
 MIT License
 
 Copyright (c) {% now 'local', '%Y' %}, {{ cookiecutter.author }}
@@ -50,7 +50,7 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
-{% elif cookiecutter.license == 'ISC license' -%}
+{% elif cookiecutter.license == 'ISC License (ISCL)' -%}
 ISC License
 
 Copyright (c) {% now 'local', '%Y' %}, {{ cookiecutter.author }}
@@ -58,7 +58,7 @@ Copyright (c) {% now 'local', '%Y' %}, {{ cookiecutter.author }}
 Permission to use, copy, modify, and/or distribute this software for any purpose with or without fee is hereby granted, provided that the above copyright notice and this permission notice appear in all copies.
 
 THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
-{% elif cookiecutter.license == 'Apache Software License 2.0' -%}
+{% elif cookiecutter.license == 'Apache Software License' -%}
 Apache Software License 2.0
 
 Copyright (c) {% now 'local', '%Y' %}, {{ cookiecutter.author }}
@@ -74,7 +74,7 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-{% elif cookiecutter.license == 'GNU General Public License v3' -%}
+{% elif cookiecutter.license == 'GNU General Public License v3 (GPLv3)' -%}
                    GNU GENERAL PUBLIC LICENSE
                       Version 3, 29 June 2007
 

--- a/{{cookiecutter.package_name}}/setup.cfg
+++ b/{{cookiecutter.package_name}}/setup.cfg
@@ -11,7 +11,7 @@ classifiers =
 {%- if cookiecutter.is_open_source %}
     License :: OSI Approved :: {{ cookiecutter.license }}
 {%- else %}
-    License :: {{ cookiecutter.license }}
+    License :: Other/Proprietary License
 {%- endif %}
     Natural Language :: English
     Operating System :: OS Independent


### PR DESCRIPTION
PyPI only accepts classifiers that exactly match one here: https://pypi.org/classifiers/

This fixes the license classifiers to match so that PyPI will accept the package.